### PR TITLE
detect expressions ending with +0x<NUM>

### DIFF
--- a/demangle-mode.el
+++ b/demangle-mode.el
@@ -190,7 +190,7 @@ changing the display style of demangled symbols (see option
 `demangle-show-as').")
 
 (defconst demangle-font-lock-keywords
-  '(("\\_<\\(?:_Z\\|_GLOBAL__[DI]_\\)[_[:alnum:]]+\\_>"
+  '(("\\_<\\(?:_Z\\|_GLOBAL__[DI]_\\)[_+[:alnum:]]+\\_>"
      0
      (progn
        (demangler-demangle)


### PR DESCRIPTION
In the examples that I tested, the mangled symbol ended with "+0x<NUMBER>", for example:
(_ZN7CxxTest14ErrorFormatter3runEv+0x18) [0xb1029a]

In the patch, I included the "+", so the expression above is also matched. The demangled output looks fine:
CxxTest::ErrorFormatter::run()+0x18

So far, I could not notice any negative side-effects.
