### PR TITLE
Add $ to the pattern of possible mangled symbol matches

### DIFF
--- a/demangle-mode.el
+++ b/demangle-mode.el
@@ -204,7 +204,7 @@ changing the display style of demangled symbols (see option
 							  (any ?. ?_ ?$)
 							  (any ?D ?I)
 							  ?_))
-					    (one-or-more (any ?_ alnum)))))))
+					    (one-or-more (any ?_ ?$ alnum)))))))
      1
      (ignore (demangle--demangle-matched-symbol (match-data)))))
   "Font-lock patterns matching mangled C++ symbols.


### PR DESCRIPTION
Lambda functions contain $ sign,
e.g. `_ZZ20reference_collapsingvENK3$_0clI1CEEDaOT_` is demangled to
`auto reference_collapsing()::$_0::operator()<C>(C&&) const`
This patch enables recognition of such symbols.